### PR TITLE
Add a deduplicator protocol to avoid duplicate records

### DIFF
--- a/Sources/PersistentHistoryTrackingKit/Protocol/DeduplicatorProtocol.swift
+++ b/Sources/PersistentHistoryTrackingKit/Protocol/DeduplicatorProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  DeduplicatorProtocol.swift
+//
+//
+//  Created by Yang Yubo on 2024/6/18.
+//
+
+import CoreData
+import Foundation
+
+public protocol TransactionDeduplicatorProtocol {
+    /// 将 transaction 中的重复数据从托管对象上下文删除
+    func callAsFunction(deduplicate transactions: [NSPersistentHistoryTransaction], in contexts: [NSManagedObjectContext])
+}


### PR DESCRIPTION
Apple official doc provides a sample for removing duplicate data:

https://developer.apple.com/documentation/coredata/sharing_core_data_objects_between_icloud_users

By providing a deduplicator protocol `TransactionDeduplicatorProtocol`, gives the framework audience a opportunity to interfere duplicate data in history transactions.