### PR TITLE
Allow pass in a custom TransactionMergerProtocol instance

### DIFF
--- a/Sources/PersistentHistoryTrackingKit/PersistentHistoryTrackingKit.swift
+++ b/Sources/PersistentHistoryTrackingKit/PersistentHistoryTrackingKit.swift
@@ -58,7 +58,7 @@ public final class PersistentHistoryTrackingKit {
     let fetcher: Fetcher
 
     /// 合并transaction到指定的托管对象上下文中（contexts）
-    let merger: Merger
+    let merger: TransactionMergerProtocol
     
     /// 删除transaction中重复数据
     let deduplicator: TransactionDeduplicatorProtocol?
@@ -193,6 +193,7 @@ public final class PersistentHistoryTrackingKit {
 
     init(logLevel: Int,
          strategy: TransactionCleanStrategy,
+         merger: TransactionMergerProtocol,
          deduplicator: TransactionDeduplicatorProtocol?,
          currentAuthor: String,
          allAuthors: [String],
@@ -243,7 +244,7 @@ public final class PersistentHistoryTrackingKit {
             includingCloudKitMirroring: includingCloudKitMirroring
         )
 
-        self.merger = Merger()
+        self.merger = merger
         self.deduplicator = deduplicator
         self.cleaner = Cleaner(backgroundContext: backgroundContext, authors: allAuthors)
         self.timestampManager = TransactionTimestampManager(userDefaults: userDefaults, maximumDuration: maximumDuration, uniqueString: uniqueString)
@@ -320,6 +321,7 @@ public extension PersistentHistoryTrackingKit {
                      batchAuthors: [String] = [],
                      userDefaults: UserDefaults,
                      cleanStrategy: TransactionCleanStrategy = .byNotification(times: 1),
+                     merger: TransactionMergerProtocol? = nil,
                      deduplicator: TransactionDeduplicatorProtocol? = nil,
                      maximumDuration: TimeInterval = 60 * 60 * 24 * 7,
                      uniqueString: String = "PersistentHistoryTrackingKit.lastToken.",
@@ -330,6 +332,7 @@ public extension PersistentHistoryTrackingKit {
         let logger = logger ?? DefaultLogger()
         self.init(logLevel: logLevel,
                   strategy: cleanStrategy,
+                  merger: merger ?? Merger(),
                   deduplicator: deduplicator,
                   currentAuthor: currentAuthor,
                   allAuthors: allAuthors,
@@ -353,6 +356,7 @@ public extension PersistentHistoryTrackingKit {
                      batchAuthors: [String] = [],
                      userDefaults: UserDefaults,
                      cleanStrategy: TransactionCleanStrategy = .byNotification(times: 1),
+                     merger: TransactionMergerProtocol? = nil,
                      deduplicator: TransactionDeduplicatorProtocol? = nil,
                      maximumDuration: TimeInterval = 60 * 60 * 24 * 7,
                      uniqueString: String = "PersistentHistoryTrackingKit.lastToken.",
@@ -364,6 +368,7 @@ public extension PersistentHistoryTrackingKit {
         let logger = logger ?? DefaultLogger()
         self.init(logLevel: logLevel,
                   strategy: cleanStrategy,
+                  merger: merger ?? Merger(),
                   deduplicator: deduplicator,
                   currentAuthor: currentAuthor,
                   allAuthors: allAuthors,

--- a/Sources/PersistentHistoryTrackingKit/Protocol/MergerProtocol.swift
+++ b/Sources/PersistentHistoryTrackingKit/Protocol/MergerProtocol.swift
@@ -13,7 +13,7 @@
 import CoreData
 import Foundation
 
-protocol TransactionMergerProtocol {
+public protocol TransactionMergerProtocol {
     /// 将 transaction 合并到指定的托管对象上下文。可以多个上下文，之间用 ，分隔
     func callAsFunction(merge transactions: [NSPersistentHistoryTransaction], into contexts: [NSManagedObjectContext])
 }


### PR DESCRIPTION
The default Merger instance can cause accidental crashes when `contexts: [NSManagedObjectContext]` contains a context that its `undoManager` set to an instance of `UndoManager`.

By exposing `TransactionMergerProtocol` protocol, we can pass a customized merger which disables/enables undo manager before and after merging. Example implementation:

```swift
class CustomTransactionMerger: TransactionMergerProtocol {
    func callAsFunction(merge transactions: [NSPersistentHistoryTransaction],
                        into contexts: [NSManagedObjectContext]) {
        for transaction in transactions {
            let notification = transaction.objectIDNotification()
            for context in contexts {
                context.perform {
                    let undoManager = context.undoManager
                    context.undoManager = nil
                    context.mergeChanges(fromContextDidSave: notification)
                    context.undoManager = undoManager
                }
            }
        }
    }
}
```
